### PR TITLE
Language filter

### DIFF
--- a/ckanext/iepnb/config.py
+++ b/ckanext/iepnb/config.py
@@ -1,8 +1,8 @@
 proxy = None
 gcontext = None
 
-#migas de pan por defecto definidas en el fichero de configuración con iepnb.breadcrumbs
-breadcrumbs = ""
+#migas de pan por defecto definidas en el fichero de configuración con iepnb.default_breadcrumbs
+default_breadcrumbs = ""
 
 #servidor al que se ha de solicitar el objeto json con el menú y las migas de pan
 server_menu = "https://iepnb-des.tragsatec.es"
@@ -11,7 +11,7 @@ server_menu = "https://iepnb-des.tragsatec.es"
 #se define en el menú ini con epnb.path_menu
 path_menu = "/api/menu_items/main"
 
-#Ruta a la descarga de migas de pan del servidor definida en el fichero de configuración con iepnb.path.breadcrumbs 
+#Ruta a la descarga de migas de pan del servidor definida en el fichero de configuración con iepnb.path.default_breadcrumbs 
 path_breadcrumbs = ""
 
 # número de etiquetas populares para mostrar en la página principal
@@ -47,8 +47,10 @@ attrs_logo_ministerio = None
 
 default_logo_ministerio='<img class="imagenMinisterio" src="{0}" alt="Logotipo del Ministerio para la transición ecológica y el reto demográfico">'
 
-footer_iepnb = {}
+footer_iepnb = None
 
 menu = None
+
+breadcrumbs = None
 
 stats = False

--- a/ckanext/iepnb/plugin.py
+++ b/ckanext/iepnb/plugin.py
@@ -29,7 +29,7 @@ class IepnbPlugin(plugins.SingletonPlugin, DefaultTranslation):
               
         iepnb_config.server_menu = config.get('iepnb.server', iepnb_config.server_menu)
         iepnb_config.path_menu = config.get('iepnb.path_menu', iepnb_config.path_menu)
-        iepnb_config.breadcrumbs = config.get('iepnb.breadcrumbs', '')
+        iepnb_config.default_breadcrumbs = config.get('iepnb.breadcrumbs', '')
         iepnb_config.proxy = config.get('iepnb.proxy', '')
         iepnb_config.popular_tags = toolkit.asint(config.get('iepnb.popular_tags', 3))
         iepnb_config.locale_default = config.get('ckan.locale_default', iepnb_config.locale_default)
@@ -38,6 +38,17 @@ class IepnbPlugin(plugins.SingletonPlugin, DefaultTranslation):
         iepnb_config.gcontext = ssl.SSLContext()
         
         iepnb_config.stats = ('stats' in config.get('ckan.plugins','').split())
+        
+        languages = config.get('ckan.locales_offered',iepnb_config.locale_default)
+        iepnb_config.menu = {}
+        iepnb_config.footer_iepnb = {}
+        iepnb_config.breadcrumbs = {}
+        for language in languages.split():
+            iepnb_config.menu[language] = None
+            iepnb_config.footer_iepnb[language] = None
+            iepnb_config.breadcrumbs[language] = None
+        
+        
     
     # ITemplateHelper    
     def get_helpers(self):

--- a/ckanext/iepnb/tests/controllers/test_home.py
+++ b/ckanext/iepnb/tests/controllers/test_home.py
@@ -73,12 +73,17 @@ class TestHome(object):
         
         self.footer = "<footer>FAKE FOOTER</footer>"
         monkeypatch.setattr("ckan.plugins.toolkit.h.iepnb_breadcrumbs", lambda x: breadcrumbs)
+        
         monkeypatch.setattr("ckan.plugins.toolkit.h.iepnb_tag_img_ministerio", lambda: '<img src="/fake_img.png"/>')
+        
+        monkeypatch.setattr("ckanext.iepnb.helpers.iepnb_tag_img_ministerio", lambda: '<img src="/fake_img.png"/>')
         monkeypatch.setattr("ckan.plugins.toolkit.h.iepnb_menu", lambda x: menu)
+        
         monkeypatch.setattr("ckan.plugins.toolkit.h.iepnb_get_footer", lambda x: self.footer)
         
-    def test_home_renders(self, app):
-
+        
+    def test_home_renders(self, monkeypatch, app):
+        self.init(monkeypatch)
         response = app.get(url_for("home.index"))
         assert "Catálogo de datos" in response.body
 

--- a/ckanext/iepnb/tests/test_helpers.py
+++ b/ckanext/iepnb/tests/test_helpers.py
@@ -57,8 +57,9 @@ class TestIepnbBreadcrumbs:
         iepnb_config.server_menu = "http://server_menu"
         iepnb_config.locale_default = "lang" 
         iepnb_config.gcontext = ""
-        iepnb_config.breadcrumbs = "default_breadcrumbs"
+        iepnb_config.default_breadcrumbs = "default_breadcrumbs"
         iepnb_config.path_breadcrumbs = ""
+        iepnb_config.breadcrumbs[iepnb_config.locale_default] = None
     
         fake_urlopen_object = Fake_urlopen()
         urlopen.side_effect = fake_urlopen_object.urlopen
@@ -70,72 +71,82 @@ class TestIepnbBreadcrumbs:
         iepnb_config.server_menu = "http://server_menu"
         iepnb_config.locale_default = "lang" 
         iepnb_config.gcontext = ""
-        iepnb_config.breadcrumbs = "default_breadcrumbs"
+        iepnb_config.default_breadcrumbs = "default_breadcrumbs"
         iepnb_config.path_breadcrumbs = "/path_breadcrumbs"
+        iepnb_config.breadcrumbs={iepnb_config.locale_default: None}
     
         fake_urlopen_object = Fake_urlopen("breadcrumbs")
         urlopen.side_effect = fake_urlopen_object.urlopen
 
         assert iepnb_helpers.iepnb_breadcrumbs() == "breadcrumbs"
-        assert fake_urlopen_object.url =="http://server_menu/lang/path_breadcrumbs"
+        assert fake_urlopen_object.url =="http://server_menu/path_breadcrumbs"
 
     def test_downloads_specified_languaje(self,iepnb_config, urlopen, capsys):
         iepnb_config.server_menu = "http://server_menu"
-        iepnb_config.locale_default = "other_lang" 
+        iepnb_config.locale_default = "lang"
+        other_lang = "other_lang"
         iepnb_config.gcontext = ""
-        iepnb_config.breadcrumbs = "default_breadcrumbs"
+        iepnb_config.default_breadcrumbs = "default_breadcrumbs"
         iepnb_config.path_breadcrumbs = "/path_breadcrumbs"
+        iepnb_config.breadcrumbs={iepnb_config.locale_default: None, other_lang: None}
     
         fake_urlopen_object = Fake_urlopen("breadcrumbs")
         urlopen.side_effect = fake_urlopen_object.urlopen
 
-        assert iepnb_helpers.iepnb_breadcrumbs(iepnb_config.locale_default) == "breadcrumbs"
+        assert iepnb_helpers.iepnb_breadcrumbs(other_lang) == "breadcrumbs"
+        assert iepnb_config.breadcrumbs.get(other_lang,None) == "breadcrumbs"
+        assert not iepnb_config.breadcrumbs.get(iepnb_config.locale_default,None)
         assert fake_urlopen_object.url =="http://server_menu/other_lang/path_breadcrumbs"
 
 @patch("ckanext.iepnb.helpers.urlopen")
 @patch("ckanext.iepnb.helpers.iepnb_config")
 class TestIepnbMenu:
     def test_downloads_menu_for_unspecified_language(self, iepnb_config, urlopen, capsys):
+        default_menu = "menú por defecto"
         iepnb_config.locale_default = "lang" 
-        iepnb_config.menu = None
+        iepnb_config.menu = {iepnb_config.locale_default:None}
         iepnb_config.server_menu = "http://server_menu"
         iepnb_config.path_menu = "/path_menu"
         iepnb_config.gcontext = ""
     
-        fake_urlopen_object = Fake_urlopen("menú por defecto")
+        fake_urlopen_object = Fake_urlopen(default_menu)
         urlopen.side_effect = fake_urlopen_object.urlopen
 
-        assert iepnb_helpers.iepnb_menu() == 'menú por defecto'
-        assert iepnb_config.menu.get(iepnb_config.locale_default,None) == 'menú por defecto'
+        assert iepnb_helpers.iepnb_menu() == default_menu
+        assert iepnb_config.menu.get(iepnb_config.locale_default,None) == default_menu
         assert fake_urlopen_object.url == "http://server_menu/path_menu"
 
     def test_downloads_menu_for_specified_default_language(self, iepnb_config, urlopen, capsys):
+        default_menu = "menú por defecto"
         iepnb_config.locale_default = "lang" 
-        iepnb_config.menu = None
+        iepnb_config.menu = {iepnb_config.locale_default:None}
         iepnb_config.server_menu = "http://server_menu"
         iepnb_config.path_menu = "/path_menu"
         iepnb_config.gcontext = ""
     
-        fake_urlopen_object = Fake_urlopen("menú por defecto")
+        fake_urlopen_object = Fake_urlopen(default_menu)
         urlopen.side_effect = fake_urlopen_object.urlopen
 
-        assert iepnb_helpers.iepnb_menu(iepnb_config.locale_default) == 'menú por defecto'
-        assert iepnb_config.menu.get(iepnb_config.locale_default,None) == 'menú por defecto'
+        assert iepnb_helpers.iepnb_menu(iepnb_config.locale_default) == default_menu
+        assert iepnb_config.menu.get(iepnb_config.locale_default,None) == default_menu
         assert fake_urlopen_object.url == "http://server_menu/path_menu"
 
     def test_downloads_menu_for_other_language(self, iepnb_config, urlopen, capsys):
+        default_menu = "menú por defecto"
+        other_menu = "menú otro lenguaje"
+        other_language = 'other_lang'
         iepnb_config.locale_default = "lang" 
-        iepnb_config.menu = None
+        iepnb_config.menu = {iepnb_config.locale_default:None, other_language:None}
         iepnb_config.server_menu = "http://server_menu"
         iepnb_config.path_menu = "/path_menu"
         iepnb_config.gcontext = ""
     
-        fake_urlopen_object = Fake_urlopen("menú otro lenguaje")
+        fake_urlopen_object = Fake_urlopen(other_menu)
         urlopen.side_effect = fake_urlopen_object.urlopen
 
-        assert iepnb_helpers.iepnb_menu('other_lang') == "menú otro lenguaje"
-        assert iepnb_config.menu.get('other_lang',None) == "menú otro lenguaje"
-        assert fake_urlopen_object.url == "http://server_menu/other_lang/path_menu"
+        assert iepnb_helpers.iepnb_menu(other_language) == other_menu
+        assert iepnb_config.menu.get(other_language,None) == other_menu
+        assert fake_urlopen_object.url == "http://server_menu/"+other_language+"/path_menu"
 
     def test_gets_yet_downloaded_menu_for_unspecified_language(self, iepnb_config, urlopen, capsys):
         iepnb_config.locale_default = "lang" 

--- a/test.ini
+++ b/test.ini
@@ -9,13 +9,13 @@ use = config:../../src/ckan/test-core.ini
 ckan.plugins = iepnb
 
 #Server to download menu and breadcrumbs. 
-iepnb.server = https://des.iepnb.es
+iepnb.server = https://iepnb-des.tragsatec.es
 
 #default breadcrumbs
 iepnb.breadcrumbs = [{"title":"Nuestros datos","description":"Nuestros datos", "relative":"/nuestros-datos"},{"title":"Catálogo de datos","description":"Catálogo de datos", "relative":"/catalogo"}]
 
 #relative path to download menu in iepnb.server. Demo path_menu in ckanext-iepnb_assets: /main.json
-iepnb.path_menu = /api/menu_items/main         
+iepnb.path_menu = /apis/menu_items/main         
 
 #number of popular tags to show at index page
 iepnb.popular_tags = 3
@@ -32,7 +32,7 @@ ckan.template_footer_end = <div role="region"><strong>TEST TEMPLATE_FOOTER_END T
 
 # Logging configuration
 [loggers]
-keys = root, ckan, sqlalchemy
+keys = root, ckan, ckanext, sqlalchemy
 
 [handlers]
 keys = console
@@ -46,8 +46,14 @@ handlers = console
 
 [logger_ckan]
 qualname = ckan
-handlers =
-level = INFO
+handlers = console
+level = WARN
+
+[logger_ckanext]
+level = DEBUG
+handlers = console
+qualname = ckanext
+propagate = 0
 
 [logger_sqlalchemy]
 handlers =

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ use = config:../../src/ckan/test-core.ini
 ckan.plugins = iepnb
 
 #Server to download menu and breadcrumbs. 
-iepnb.server = https://iepnb-des.tragsatec.es
+iepnb.server = https://fake.iepnb-des.tragsatec.es
 
 #default breadcrumbs
 iepnb.breadcrumbs = [{"title":"Nuestros datos","description":"Nuestros datos", "relative":"/nuestros-datos"},{"title":"Catálogo de datos","description":"Catálogo de datos", "relative":"/catalogo"}]
@@ -29,6 +29,10 @@ ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css
 # use <strong> so we can check that html is *not* escaped, div is used for a11y compliance
 ckan.template_footer_end = <div role="region"><strong>TEST TEMPLATE_FOOTER_END TEST</strong></div>
 
+ckan.locale_default = es
+ckan_locale_order = es ca eu gl en
+ckan.locales_offered = es ca eu gl en
+ckan.locales_filtered_out = es_ES
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Cuando se solicita por primera vez una página a ckan, este solicita al drupal el menú en un json, y descarga la página principal para copiar el pie de página. Esta solicitud se hace en el idioma en el que se ha realizado la petición a ckan. Una vez se obtiene la respuesta del drupal, esta se almacena y no se vuelve a pedir durante la vida del proceso ckan.

En el caso de que estos datos se soliciten en un idioma para el que Drupal no tiene definida la respuesta, se produce un error y no se genera bien la página. Además como no se han podido recuperar datos, no se ha almacenado ninguna información en memoria, por lo que la siguiente vez que se solicite una página en ese idioma "desconocido", se repetirá la petición a Drupal.

El problema real ocurre cuando determinados SEO intentan recuperar todas las versiones posibles del catálogo, construyendo las url para cada idioma. En este caso al haber dado un error la página se continua repitiendo la solicitud, llenando el archivo de logs de errores que pueden hacer difícil localizar los logs de errores más importantes.

Esta modificación hace que al solicitar páginas en un idioma que no está entre los ofrecidos por ckan (ckan.locales_offered en el .ini), en vez de en el idioma solicitado se requieran los datos en el idioma definido por defecto (ckan.locale_default). evidentemente si ya se han solicitado antes a Drupal en el idioma por defecto, no se repite la petición y se emplea la información almacenada en memoria.

Incidentalmente se ha mejorado la función test_home_renders (de los test creados para la extensión), ya que la versión anterior no recogía bien la sustitución de las funciones que accedían al Drupal, por lo que durante el test se estaba accediendo realmente a este servidor. Este intento de acceso daba problemas cuando se ejecutaban los test en un entorno que no tuviera acceso a ese servidor (por ejemplo, en git).