### PR TITLE
Retorno a versión estable 2.0.2.1  y correción de fallos menores

### DIFF
--- a/ckanext/iepnb/public/css/iepnb.css
+++ b/ckanext/iepnb/public/css/iepnb.css
@@ -584,7 +584,6 @@ button.image {
 	display: none;
 }
 
-
 .fade:not(.show) {
   opacity: unset;
 }
@@ -925,4 +924,9 @@ button.image {
 
 footer, footer .nav-item > a {
 	line-height: var(--bs-body-line-height);
+}
+
+/* Fixes */
+.nav-item button::after {
+    display: none;
 }

--- a/ckanext/iepnb/templates/home/columna_derecha.html
+++ b/ckanext/iepnb/templates/home/columna_derecha.html
@@ -21,7 +21,7 @@
                       <h1 class="catalogo_datos_con_linea">{% trans %}Buscar{% endtrans %}</h1>
                     </div>
                     <div class="contenedor_input_principal">
-                      <input aria-label="{% block header_site_search_label %}{{ _('Buscar conjuntos de datos') }}{% endblock %}" type="text" class="input_principal" autofocus="true" maxlength="256" name="Etiqueta-2" data-name="Etiqueta 2" placeholder="{{placeholder}}" id="Etiqueta-2" required="">
+                      <input aria-label="{% block header_site_search_label %}{{ _('Buscar conjuntos de datos') }}{% endblock %}" type="text" class="input_principal" autofocus="true" maxlength="256" name="q" value="" autocomplete="off" placeholder="{% block search_placeholder %}{{ placeholder }}{% endblock %}">
                        <button class="image"><img src="{{ h.url_for_static('img/icon_tab_lupa.svg') }}" loading="lazy" alt="Icono buscar" class="image-3"></button>
                      </div>
                    </form>

--- a/ckanext/iepnb/templates/home/columna_derecha.html
+++ b/ckanext/iepnb/templates/home/columna_derecha.html
@@ -10,7 +10,7 @@
             <div class="contenedor_introduccion">
               <div class="resaltado">
               {%- set iepnb_url = "https://www.miteco.gob.es/" + request.environ.CKAN_LANG + "/biodiversidad/temas/inventarios-nacionales/inventario-espanol-patrimonio-natural-biodiv" %}
-                 <p class="parrafo_catalogo_datos">{% trans %}El catálogo de datos abiertos del <a href="{{ iepnb_url }}" style="color: #333333;"><strong>Inventario Español del Patrimonio Natural y la Biodiversidad</strong></a> consta de una aplicación con tecnología CKAN que se utiliza para distribuir mapas, datos y metadatos espaciales y un <a href="{{ base_url }}/csw" style="color: #333333;"><strong>catálogo CSW</strong></a> (estándar OGC) para la publicación y descubrimiento de metadatos sobre recursos espaciales en la web.{% endtrans %}</p>
+                 <p class="parrafo_catalogo_datos">{% trans %}La base de datos  <a href="https://www.miteco.gob.es/es/biodiversidad/servicios/banco-datos-naturaleza/eidos_acceso.html" style="color: #333333;"><strong>EIDOS</strong></a> incorpora la información oficial sobre las especies silvestres presentes en España que ha ido recopilando el MITECO en sus distintos proyectos en los últimos años. Este portal consta de una aplicación con tecnología <a href="https://ckan.org/" style="color: #333333;"><strong>CKAN</strong></a> que se utiliza para distribuir los datos de especies.{% endtrans %}</p>
               </div>
             </div>
             <div class="contenedor_buscador_datos">

--- a/ckanext/iepnb/templates/home/columna_derecha.html
+++ b/ckanext/iepnb/templates/home/columna_derecha.html
@@ -10,7 +10,7 @@
             <div class="contenedor_introduccion">
               <div class="resaltado">
               {%- set iepnb_url = "https://www.miteco.gob.es/" + request.environ.CKAN_LANG + "/biodiversidad/temas/inventarios-nacionales/inventario-espanol-patrimonio-natural-biodiv" %}
-                 <p class="parrafo_catalogo_datos">{% trans %}La base de datos  <a href="https://www.miteco.gob.es/es/biodiversidad/servicios/banco-datos-naturaleza/eidos_acceso.html" style="color: #333333;"><strong>EIDOS</strong></a> incorpora la información oficial sobre las especies silvestres presentes en España que ha ido recopilando el MITECO en sus distintos proyectos en los últimos años. Este portal consta de una aplicación con tecnología <a href="https://ckan.org/" style="color: #333333;"><strong>CKAN</strong></a> que se utiliza para distribuir los datos de especies.{% endtrans %}</p>
+                 <p class="parrafo_catalogo_datos">{% trans %}La base de datos  <a href="https://des.iepnb.es/areas-tematicas/especies-silvestres/eidos" style="color: #333333;"><strong>EIDOS</strong></a> incorpora la información oficial sobre las especies silvestres presentes en España que ha ido recopilando el MITECO en sus distintos proyectos en los últimos años. Este portal consta de una aplicación con tecnología <a href="https://ckan.org/" style="color: #333333;"><strong>CKAN</strong></a> que se utiliza para distribuir los datos de especies.{% endtrans %}</p>
               </div>
             </div>
             <div class="contenedor_buscador_datos">

--- a/ckanext/iepnb/templates/home/snippets/featured_organization.html
+++ b/ckanext/iepnb/templates/home/snippets/featured_organization.html
@@ -1,8 +1,7 @@
-{% ckan_extends %}
 {% set organizations = h.get_featured_organizations(2) %}
 
 {% for organization in organizations %}
   <div class="box">
-    {% snippet 'snippets/organization_item.html', organization=organization %}
+    {% snippet 'snippets/organization_item.html', organization=organization, truncate=50, truncate_title=35 %}
   </div>
 {% endfor %}

--- a/ckanext/iepnb/templates/home/snippets/featured_organization.html
+++ b/ckanext/iepnb/templates/home/snippets/featured_organization.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+{% set organizations = h.get_featured_organizations(2) %}
+
+{% for organization in organizations %}
+  <div class="box">
+    {% snippet 'snippets/organization_item.html', organization=organization %}
+  </div>
+{% endfor %}


### PR DESCRIPTION
La rama `develop` está corrompida a partir de: https://github.com/OpenDataGIS/ckanext-iepnb/commit/b9d344f1619e43f87b6d34f2caf04b87a919a452

![image](https://github.com/OpenDataGIS/ckanext-iepnb/assets/96422458/643f0935-3cdf-4530-a7c7-b2efd8ef616c)
